### PR TITLE
Использовать последние обновления clean-css

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ exports.Tech = cssbase.Tech.inherit({
         CleanCSSOptions.rebase = typeof CleanCSSOptions.noRebase === 'undefined' ? true : false;
         CleanCSSOptions.processImport = typeof CleanCSSOptions.processImport === 'undefined' ? false : CleanCSSOptions.processImport;
 
-        return new CleanCSS(CleanCSSOptions).minify(content);
+        return new CleanCSS(CleanCSSOptions).minify(content).styles;
     }
 
 });

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ exports.Tech = cssbase.Tech.inherit({
         var CleanCSS = require('clean-css');
 
         var CleanCSSOptions = this.opts.techOptions.cleancss || {};
-        CleanCSSOptions.noRebase = typeof CleanCSSOptions.noRebase === 'undefined' ? false : CleanCSSOptions.noRebase;
+        CleanCSSOptions.rebase = typeof CleanCSSOptions.noRebase === 'undefined' ? true : false;
         CleanCSSOptions.processImport = typeof CleanCSSOptions.processImport === 'undefined' ? false : CleanCSSOptions.processImport;
 
         return new CleanCSS(CleanCSSOptions).minify(content);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "borschik CSS tech based on CleanCSS",
   "main": "index.js",
   "dependencies": {
-    "clean-css": "git://github.com/jakubpawlowicz/clean-css#7ea106e"
+    "clean-css": "3.0.7"
   },
   "peerDependencies": {
     "borschik": ">=1.0.5"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "borschik CSS tech based on CleanCSS",
   "main": "index.js",
   "dependencies": {
-    "clean-css": "git://github.com/jakubpawlowicz/clean-css#a5e416dbb8bcf154f52a5d95a824ee4d8535a1c9"
+    "clean-css": "git://github.com/jakubpawlowicz/clean-css#4e80090"
   },
   "peerDependencies": {
     "borschik": ">=1.0.5"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "borschik CSS tech based on CleanCSS",
   "main": "index.js",
   "dependencies": {
-    "clean-css": "git://github.com/jakubpawlowicz/clean-css#4e80090"
+    "clean-css": "git://github.com/jakubpawlowicz/clean-css#7ea106e"
   },
   "peerDependencies": {
     "borschik": ">=1.0.5"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "borschik CSS tech based on CleanCSS",
   "main": "index.js",
   "dependencies": {
-    "clean-css": "2.2.16"
+    "clean-css": "git://github.com/jakubpawlowicz/clean-css#a5e416dbb8bcf154f52a5d95a824ee4d8535a1c9"
   },
   "peerDependencies": {
     "borschik": ">=1.0.5"


### PR DESCRIPTION
*Последний коммит из ветки master*

Сейчас в clean-css нет возможности указать режим совместимости. И свойства типа
```css
background-size: 10px 10px;
background: url(...) 50% 50%;
```
cливаются в (position+size):
```
background: url(...) 50% 50%/21px 21px;
```
Такую запись не понимают `IE<9` и старые версии `android`. На них все ломается.

В ветке [master](https://github.com/jakubpawlowicz/clean-css/blob/master/lib/utils/compatibility.js) уже реализованна возможность указания режима совместимости. Она передается опцией:
```js
{
    compatibility: 'ie7'
}
```