### PR TITLE
Updated clean-css up to 4.2.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,7 @@ exports.Tech = cssbase.Tech.inherit({
     minimize: function(content) {
         var CleanCSS = require('clean-css');
 
-        var CleanCSSOptions = this.opts.techOptions.cleancss || {};
-        CleanCSSOptions.rebase = typeof CleanCSSOptions.noRebase === 'undefined' ? true : false;
-        CleanCSSOptions.processImport = typeof CleanCSSOptions.processImport === 'undefined' ? false : CleanCSSOptions.processImport;
-
-        return new CleanCSS(CleanCSSOptions).minify(content).styles;
+        return new CleanCSS(this.opts.techOptions.cleancss).minify(content).styles;
     }
 
 });

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "borschik-tech-cleancss",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "borschik CSS tech based on CleanCSS",
   "main": "index.js",
   "dependencies": {
-    "clean-css": "3.4.8"
+    "clean-css": "4.2.1"
   },
   "peerDependencies": {
     "borschik": ">=1.0.5"


### PR DESCRIPTION
Обновляю версию тк `cleancss` без разбору мерджил селекторы и такие селекторы как `:focus-within` ломали группы селекторов.

В  версии 4 они это исправили добавив whitelist разрешенных к мержду псевдоклассов